### PR TITLE
Add support for Steam Input controllers

### DIFF
--- a/dvDirectInput/Input.cs
+++ b/dvDirectInput/Input.cs
@@ -124,9 +124,9 @@ namespace dvDirectInput
 				Main.mod.Logger.Log($"Joystick Properties for {prop.Name}");
 				if (joystick.GetType().GetProperty(prop.Name).GetValue(joystick) == null)
 					continue;
-				if (joystick.GetType().GetProperty(prop.Name).GetValue(joystick).GetType().GetProperties().Length > 0)
+				if (prop.GetValue(joystick).GetType().GetProperties().Length > 0)
 				{
-					foreach (var subprop in joystick.GetType().GetProperty(prop.Name).GetValue(joystick).GetType().GetProperties())
+					foreach (var subprop in prop.GetValue(joystick).GetType().GetProperties())
 					{
 						string val = "";
 						try
@@ -165,10 +165,11 @@ namespace dvDirectInput
 			Main.mod.Logger.Log($"Joystick Objects");
 			foreach (var obj in joystick.GetObjects())
 			{
-				Main.mod.Logger.Log($"Joystick Object Fields");
+				Main.mod.Logger.Log($"Joystick Object Fields: {obj.Name}");
 				foreach (var field in obj.GetType().GetFields())
 				{
-					Main.mod.Logger.Log($"ID: {joystick.Properties.JoystickId}, Device: {joystick.Properties.ProductName}, {field.Name}: {field.GetValue(obj)}");
+					Main.mod.Logger.Log($"Joystick Object Fields: {obj.Name}: {field.Name}");
+					Main.mod.Logger.Log($"ID: {device.InstanceGuid}, Device: {joystick.Properties.ProductName}, {field.Name}: {field.GetValue(obj)}");
 				}
 
 				Main.mod.Logger.Log($"Joystick Object Properties");

--- a/dvDirectInput/Input.cs
+++ b/dvDirectInput/Input.cs
@@ -25,12 +25,15 @@ namespace dvDirectInput
 			// Axes 0 - 65535
 			// Button 0, 128
 			// POV -1 (released), 0 (up), 4500, 9000(right), 13500, 18000(down), 22500, 27000(left), 31500
-			public float NormalisedValue()
+			//
+			// 'min' and 'max' support mapping the value into a user-supplied virtual axis to share a physical access across multiple controls.
+			public float NormalisedValue(int min, int max)
 			{
 				var inputFlags = JoystickObj.GetObjectInfoByOffset((int)Offset).ObjectId.Flags;
 
-				if ((inputFlags & DeviceObjectTypeFlags.Axis) != 0)
-					return (float)Value / 65535;
+				if ((inputFlags & DeviceObjectTypeFlags.Axis) != 0) {
+					return (float)(Main.Bound(min, Value, max)-min) / (max-min);
+				}
 
 				if ((inputFlags & DeviceObjectTypeFlags.Button) != 0)
 					return (float)Value / 128;
@@ -40,7 +43,7 @@ namespace dvDirectInput
 
 			public override string ToString()
 			{
-				return string.Format(CultureInfo.InvariantCulture, $"ID: {Index}, Offset: {Offset}, Value: {Value}, Normalised Value {NormalisedValue()}, Timestamp {Timestamp}");
+				return string.Format(CultureInfo.InvariantCulture, $"ID: {Index}, Offset: {Offset}, Value: {Value}, Normalised Value {NormalisedValue(0, 65535)}, Timestamp {Timestamp}");
 			}
 		}
 

--- a/dvDirectInput/LocoControl.cs
+++ b/dvDirectInput/LocoControl.cs
@@ -29,8 +29,11 @@ namespace dvDirectInput
 					{
 						var control = new ControlReference();
 						if (!PlayerManager.Car?.interior.GetComponentInChildren<InteriorControlsManager>().TryGetControl((ControlType)configControl.idx, out control) ?? true) return;
-						control.controlImplBase?.SetValue(configControl.val.InvertControl ? 1.0f - input.NormalisedValue() : input.NormalisedValue());
-						break;
+						var val = input.NormalisedValue(configControl.val.RangeMin, configControl.val.RangeMax);
+						if (configControl.val.InvertControl) {
+							val = 1.0f - val;
+						}
+						control.controlImplBase?.SetValue(val);
 					}
 				}
 			}

--- a/dvDirectInput/LocoControl.cs
+++ b/dvDirectInput/LocoControl.cs
@@ -25,7 +25,7 @@ namespace dvDirectInput
 				foreach (var configControl in Main.settings.configControls.Select((val, idx) => new { idx, val }))
 				{
 					// We should probably do a lookup for the inputs against the mappings instead of iterating
-					if (configControl.val.Enabled && input.JoystickObj.Properties.JoystickId == configControl.val.DeviceId && input.Offset == configControl.val.DeviceOffset)
+					if (configControl.val.Enabled && input.Index == configControl.val.DeviceId && input.Offset == configControl.val.DeviceOffset)
 					{
 						var control = new ControlReference();
 						if (!PlayerManager.Car?.interior.GetComponentInChildren<InteriorControlsManager>().TryGetControl((ControlType)configControl.idx, out control) ?? true) return;

--- a/dvDirectInput/Main.cs
+++ b/dvDirectInput/Main.cs
@@ -99,7 +99,9 @@ namespace dvDirectInput
 				return e.Message;
 			}
 		}
-
+		public static int Bound(int min, int val, int max) {
+			return val < min ? min : val > max ? max : val;
+		}
 	}
 
 }

--- a/dvDirectInput/Settings.cs
+++ b/dvDirectInput/Settings.cs
@@ -19,6 +19,8 @@ namespace dvDirectInput
 			public int DeviceId = 0;
 			public JoystickOffset DeviceOffset = JoystickOffset.X;
 			public bool InvertControl = false;
+			public int RangeMin = 0;
+			public int RangeMax = 65535;
 		}
 		public override void Save(UnityModManager.ModEntry modEntry)
 		{
@@ -62,8 +64,14 @@ namespace dvDirectInput
 				GUILayout.Label("Device Offset", GUILayout.Width(100));
 				configControl.val.DeviceOffset = (JoystickOffset)int.Parse(GUILayout.TextField(((int)configControl.val.DeviceOffset).ToString()));
 				GUILayout.EndHorizontal();
+				GUILayout.BeginHorizontal(GUILayout.Width(200));
 				configControl.val.InvertControl = GUILayout.Toggle(configControl.val.InvertControl, "Invert");
-
+				GUILayout.EndHorizontal();
+				GUILayout.BeginHorizontal(GUILayout.Width(200));
+				GUILayout.Label("Axis Range (min, max)", GUILayout.Width(100));
+				configControl.val.RangeMin = Main.Bound(0, int.Parse(GUILayout.TextField(configControl.val.RangeMin.ToString())), 65535);
+				configControl.val.RangeMax = Main.Bound(0, int.Parse(GUILayout.TextField(configControl.val.RangeMax.ToString())), 65535);
+				GUILayout.EndHorizontal();
 				GUILayout.EndVertical();
 			}
 			GUILayout.EndVertical();


### PR DESCRIPTION
Steam Input provides a way to create virtual controllers that are calibrated through the Steam libraries (including ~arbitrary remapping of axes and buttons), then presents the resulting calibrated controller to other applications as a generic joystick.

Trying this out with a Zuiki "One Handle MasCon for Nintendo Switch" however, I found that the mod would fail to initialize, and the logs reported some exceptions with unimplemented functions. I figured I would take a stab at resolving those issues.

While I was at it, I thought it would be also interesting to include a feature to allow multiple train controls to be mapped onto a single axis. For instance, this can be used to assign the lower range to the independent brake and the upper range to the train brake. This way, a single physical movement can move through multiple in-game brake levers without additional hardware.

For more details, see the individual commit messages.